### PR TITLE
Add support for NetBox 4.6

### DIFF
--- a/netbox_slm/migrations/0007_softwareproductinstallation_cluster.py
+++ b/netbox_slm/migrations/0007_softwareproductinstallation_cluster.py
@@ -24,6 +24,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddConstraint(
             model_name='softwareproductinstallation',
-            constraint=models.CheckConstraint(check=models.Q(models.Q(('cluster__isnull', True), ('device__isnull', False), ('virtualmachine__isnull', True)), models.Q(('cluster__isnull', True), ('device__isnull', True), ('virtualmachine__isnull', False)), models.Q(('cluster__isnull', False), ('device__isnull', True), ('virtualmachine__isnull', True)), _connector='OR'), name='netbox_slm_softwareproductinstallation_platform', violation_error_message='Installation requires exactly one platform destination.'),
+            constraint=models.CheckConstraint(condition=models.Q(models.Q(('cluster__isnull', True), ('device__isnull', False), ('virtualmachine__isnull', True)), models.Q(('cluster__isnull', True), ('device__isnull', True), ('virtualmachine__isnull', False)), models.Q(('cluster__isnull', False), ('device__isnull', True), ('virtualmachine__isnull', True)), _connector='OR'), name='netbox_slm_softwareproductinstallation_platform', violation_error_message='Installation requires exactly one platform destination.'),
         ),
     ]

--- a/netbox_slm/models.py
+++ b/netbox_slm/models.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
-from django.utils.html import format_html, urlencode
+from django.utils.html import format_html
 from license_expression import Licensing, get_spdx_licensing
 
 from netbox.models import NetBoxModel
@@ -37,10 +37,10 @@ class SoftwareProduct(NetBoxModel):
 
     def get_installation_count(self):
         count = SoftwareProductInstallation.objects.filter(software_product_id=self.pk).count()
-        query_string = urlencode(dict(software_product_id=self.pk))
-        search_target = reverse("plugins:netbox_slm:softwareproductinstallation_list")
-        # Can be composed directly with reverse(query=) in Django 5.2, see https://code.djangoproject.com/ticket/25582
-        return format_html(f"<a href='{search_target}?{query_string}'>{count}</a>") if count else "0"
+        search_target = reverse(
+            "plugins:netbox_slm:softwareproductinstallation_list", query={"software_product_id": self.pk}
+        )
+        return format_html("<a href='{}'>{}</a>", search_target, count) if count else "0"
 
 
 class SoftwareReleaseTypes(models.TextChoices):
@@ -83,10 +83,8 @@ class SoftwareProductVersion(NetBoxModel):
 
     def get_installation_count(self):
         count = SoftwareProductInstallation.objects.filter(version_id=self.pk).count()
-        query_string = urlencode(dict(version_id=self.pk))
-        search_target = reverse("plugins:netbox_slm:softwareproductinstallation_list")
-        # Can be composed directly with reverse(query=) in Django 5.2, see https://code.djangoproject.com/ticket/25582
-        return format_html(f"<a href='{search_target}?{query_string}'>{count}</a>") if count else "0"
+        search_target = reverse("plugins:netbox_slm:softwareproductinstallation_list", query={"version_id": self.pk})
+        return format_html("<a href='{}'>{}</a>", search_target, count) if count else "0"
 
 
 class SoftwareProductInstallation(NetBoxModel):
@@ -109,7 +107,7 @@ class SoftwareProductInstallation(NetBoxModel):
         constraints = [
             models.CheckConstraint(
                 name="%(app_label)s_%(class)s_platform",
-                check=(
+                condition=(
                     models.Q(device__isnull=False, virtualmachine__isnull=True, cluster__isnull=True)
                     | models.Q(device__isnull=True, virtualmachine__isnull=False, cluster__isnull=True)
                     | models.Q(device__isnull=True, virtualmachine__isnull=True, cluster__isnull=False)


### PR DESCRIPTION
Closes #80 

This PR adds support for NetBox 4.6.

Two changes:

* In Django 6.0, the `check` keyword of `CheckConstraint` was removed (deprecated in 5.1, replaced by `condition`)
* Use parameter `query` in `reverve`